### PR TITLE
Allow createFromTimestamp to recognise the float and string values returned from `microtime()`

### DIFF
--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -40,7 +40,7 @@ class DateTime extends \DateTime
     /**
      * Create a new instance from a unix timestamp
      *
-     * @param int $timestamp
+     * @param int|float|string $timestamp
      * @param DateTimeZone|null $timezone
      *
      * @return self
@@ -50,7 +50,19 @@ class DateTime extends \DateTime
      */
     public static function createFromTimestamp($timestamp, DateTimeZone $timezone = null)
     {
-        return static::instance('now', $timezone)->setTimestamp($timestamp);
+        $timezone = $timezone ?: DateTimeZone::UTC();
+
+        if (is_float($timestamp)) {
+            return static::createFromFormat('U.u', $timestamp)->setTimezone($timezone);
+        }
+
+        if (is_string($timestamp)) {
+            list($milli, $seconds) = explode(' ', $timestamp);
+            $float = number_format((double) $milli + (int) $seconds, 6, '.', '');
+            return static::createFromFormat('U.u', $float)->setTimezone($timezone);
+        }
+
+        return static::instance('now', $timezone)->setTimestamp((int) $timestamp);
     }
 
     /**

--- a/tests/DateTime/Creating.php
+++ b/tests/DateTime/Creating.php
@@ -94,8 +94,42 @@ class Creating extends TestCase
     {
         $a = DateTime::createFromTimestamp(1594283757);
         $b = DateTime::createFromTimestamp(1594283757, DateTimeZone::AddisAbabaAfrica());
-        $this->assertSame('2020-07-09 08:35:57', $a->format('Y-m-d H:i:s'));
-        $this->assertSame('2020-07-09 11:35:57', $b->format('Y-m-d H:i:s'));
+        $this->assertSame('2020-07-09 08:35:57 1594283757.000000', $a->format('Y-m-d H:i:s U.u'));
+        $this->assertSame('2020-07-09 11:35:57 1594283757.000000', $b->format('Y-m-d H:i:s U.u'));
+    }
+
+    /**
+     * Testing create from timestamp using the string value from `microtime(false)`
+     *
+     * @throws Exception
+     *
+     * @return void
+     *
+     * @covers \Kusabi\Date\DateTime::createFromTimestamp
+     */
+    public function testCreateFromTimestampMicroTimeFalse()
+    {
+        $a = DateTime::createFromTimestamp('0.46060200 1594283757');
+        $b = DateTime::createFromTimestamp('0.46060200 1594283757', DateTimeZone::AddisAbabaAfrica());
+        $this->assertSame('2020-07-09 08:35:57 1594283757.460602', $a->format('Y-m-d H:i:s U.u'));
+        $this->assertSame('2020-07-09 11:35:57 1594283757.460602', $b->format('Y-m-d H:i:s U.u'));
+    }
+
+    /**
+     * Testing create from timestamp using the float value from `microtime(true)`
+     *
+     * @throws Exception
+     *
+     * @return void
+     *
+     * @covers \Kusabi\Date\DateTime::createFromTimestamp
+     */
+    public function testCreateFromTimestampMicroTimeTrue()
+    {
+        $a = DateTime::createFromTimestamp(1594283757.4606);
+        $b = DateTime::createFromTimestamp(1594283757.4606, DateTimeZone::AddisAbabaAfrica());
+        $this->assertSame('2020-07-09 08:35:57 1594283757.460600', $a->format('Y-m-d H:i:s U.u'));
+        $this->assertSame('2020-07-09 11:35:57 1594283757.460600', $b->format('Y-m-d H:i:s U.u'));
     }
 
     /**


### PR DESCRIPTION
When calling DateTime::createFromTimestamp you can pass either;

- A unix timestamp as returned from `time()` `1594283757`
- A float microtime as returned from `microtime(true)` `594283757.4606`
- A string microtime as returned from `microtime(false)` `"0.46060200 1594283757"`